### PR TITLE
Corrected vault injector network policy

### DIFF
--- a/vault/injector/install/015-NetworkPolicy-vault-injector.yaml
+++ b/vault/injector/install/015-NetworkPolicy-vault-injector.yaml
@@ -14,5 +14,5 @@ spec:
     - from:
         - namespaceSelector: {}
       ports:
-      - port: 443
+      - port: 8080
         protocol: TCP


### PR DESCRIPTION
Vault injector pod exposes 8080, not 443